### PR TITLE
Revert support for proxy headers and add https forcing middleware

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ from flask_login import LoginManager, current_user
 from flask_socketio import SocketIO, disconnect, emit, join_room, leave_room
 
 from config import *
+import middleware
 from models import User
 from oauth import oauth, user
 
@@ -32,6 +33,10 @@ port = int(os.environ.get("PORT", 5000))
 
 # construct app
 app = Flask(__name__)
+
+if os.environ.get('USE_HTTPS', 'false').lower() == 'true':
+    app.wsgi_app = middleware.ForceHttps(app.wsgi_app)
+
 app.config["SECRET_KEY"] = secrets.token_urlsafe(16)
 app.register_blueprint(user)
 

--- a/app.py
+++ b/app.py
@@ -7,7 +7,6 @@ import secrets
 from flask import Flask, render_template, request
 from flask_login import LoginManager, current_user
 from flask_socketio import SocketIO, disconnect, emit, join_room, leave_room
-from werkzeug.middleware.proxy_fix import ProxyFix
 
 from config import *
 from models import User
@@ -33,7 +32,6 @@ port = int(os.environ.get("PORT", 5000))
 
 # construct app
 app = Flask(__name__)
-app.wsgi_app = ProxyFix(app.wsgi_app, x_host=1)
 app.config["SECRET_KEY"] = secrets.token_urlsafe(16)
 app.register_blueprint(user)
 

--- a/middleware.py
+++ b/middleware.py
@@ -1,0 +1,12 @@
+class ForceHttps(object):
+    """
+    Work around a bug with Azure Container Apps ingress. Because they don't set
+    proxy headers, we need to force Flask to generate https URLs in
+    url_for(external=True) calls.
+    """
+    def __init__(self, app):
+        self.app = app
+
+    def __call__(self, environ, start_response):
+        environ["wsgi.url_scheme"] = "https"
+        return self.app(environ, start_response)


### PR DESCRIPTION
This PR reverts an earlier change to read proxy headers - the way the app is hosted now does not set them. Unfortunately, we need to add another change in order to force url_for() to generate https URLs.